### PR TITLE
feat: Emit more pasting events + cleanup some code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Function                               | Type       | Description
   v-on:handle-up-drag-size-header      | Function   | Fired when the header size changed
   v-on:thead-td-sort                   | Function   | When you press the button sort
   v-on:tbody-undo-data                 | Function   | When you hit Ctrl / Cmd + Z for undo
+  v-on:tbody-paste-data                | Function   | When you paste data to a cell
   v-on:tbody-up-dragtofill             | Function   | Fired when pressed up on dragToFill
   v-on:tbody-move-dragtofill           | Function   | Fired when moved on dragToFill
   v-on:tbody-nav-backspace             | Function   | When you press backspace on cell (event, actualElement, actualCol, rowIndex, colIndex)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+export function cleanProperty(element) {
+  let { style } = element;
+
+  if (!style) {
+    style = {};
+  }
+
+  style.setProperty("--rectangleWidth", "100%");
+  style.setProperty("--rectangleHeight", "40px");
+  style.setProperty("--rectangleTop", 0);
+  style.setProperty("--rectangleBottom", 0);
+}

--- a/src/mixins/VueTable/moveOnTable.js
+++ b/src/mixins/VueTable/moveOnTable.js
@@ -1,4 +1,6 @@
-// eslint-disable-next-line import/prefer-default-export
+import { cleanProperty } from "../../helpers";
+
+/* eslint-disable-next-line import/prefer-default-export */
 export const moveOnTable = {
   data() {
     return {
@@ -454,6 +456,13 @@ export const moveOnTable = {
       this.changeData(rowIndex, header);
     },
     updateSelectedCell(header, rowIndex, colIndex) {
+      const td = this.$refs[`${this.customTable}-vueTbody`].$refs[
+        `td-${this.customTable}-${colIndex}-${rowIndex}`
+      ][0];
+
+      this.tbodyData[rowIndex][header].stateCopy = false;
+      cleanProperty(td);
+
       if (!this.setFirstCell) {
         this.$set(this.tbodyData[rowIndex][header], "rectangleSelection", true);
         this.setFirstCell = true;


### PR DESCRIPTION
I needed to have more events when copying / pasting because the `changeValue` event is too global (it's impossible to differenciate a value change from a paste and a simple select).

I also cleaned some code and renamed some variables to more appropriate names.

_NB: I already use this code in production_